### PR TITLE
remove example from sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,7 +9,4 @@
   <url>
     <loc>https://raw.githubusercontent.com/BeBOP-OBON/TechOceanS_protocol_collection/main/odis_metadata/Colorimetric_LAMP.json</loc>
   </url>
-  <url>
-    <loc>https://raw.githubusercontent.com/BeBOP-OBON/TechOceanS_protocol_collection/main/odis_metadata/example.json</loc>
-  </url>
 </urlset>


### PR DESCRIPTION
- blank JSON file is causing issues downstream (resulting in a record named `Name or title of the document`)